### PR TITLE
feat(dedupe transform): Allow dedupe transform to specify what fields to ignore rather than to match (#1732)

### DIFF
--- a/.meta/transforms/dedupe.toml
+++ b/.meta/transforms/dedupe.toml
@@ -18,10 +18,16 @@ required = true
 [transforms.dedupe.options.fields.children.match]
 type = "[string]"
 common = true
-required = true
 examples = [["field1", "field2"]]
 default = ["timestamp"]
 description = "The field names considered when deciding if an Event is a duplicate."
+
+[transforms.dedupe.options.fields.children.ignore]
+type = "[string]"
+common = true
+examples = [["field1", "field2"]]
+description = "The field names to ignore when deciding if an Event is a duplicate."
+
 
 [transforms.dedupe.options.cache]
 type = "table"

--- a/config/vector.spec.toml
+++ b/config/vector.spec.toml
@@ -1075,9 +1075,16 @@ dns_servers = ["0.0.0.0:53"]
   #
 
   [transforms.dedupe.fields]
+    # The field names to ignore when deciding if an Event is a duplicate.
+    #
+    # * optional
+    # * no default
+    # * type: [string]
+    ignore = ["field1", "field2"]
+
     # The field names considered when deciding if an Event is a duplicate.
     #
-    # * required
+    # * optional
     # * default: ["timestamp"]
     # * type: [string]
     match = ["field1", "field2"]

--- a/src/transforms/dedupe.rs
+++ b/src/transforms/dedupe.rs
@@ -11,11 +11,13 @@ use std::any::TypeId;
 use std::collections::BTreeMap;
 use string_cache::DefaultAtom as Atom;
 
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Deserialize, Serialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
-pub struct FieldMatchConfig {
+pub enum FieldMatchConfig {
     #[serde(rename = "match")]
-    pub match_fields: Vec<Atom>,
+    MatchFields(Vec<Atom>),
+    #[serde(rename = "ignore")]
+    IgnoreFields(Vec<Atom>),
 }
 
 #[derive(Deserialize, Serialize, Debug)]
@@ -38,9 +40,7 @@ fn default_cache_config() -> CacheConfig {
 }
 
 fn default_field_match_config() -> FieldMatchConfig {
-    FieldMatchConfig {
-        match_fields: vec!["timestamp".into()],
-    }
+    FieldMatchConfig::MatchFields(vec!["timestamp".into()])
 }
 
 pub struct Dedupe {
@@ -57,7 +57,7 @@ impl TransformConfig for DedupeConfig {
     fn build(&self, _cx: TransformContext) -> crate::Result<Box<dyn Transform>> {
         Ok(Box::new(Dedupe::new(
             self.cache.num_entries,
-            self.fields.match_fields.clone(),
+            self.fields.clone(),
         )))
     }
 
@@ -74,7 +74,30 @@ impl TransformConfig for DedupeConfig {
     }
 }
 
-type CacheEntry = Vec<Option<(TypeId, Bytes)>>;
+/**
+* A CacheEntry comes in two forms, depending on the FieldMatchConfig in use.
+*
+* When matching fields, a CacheEntry contains a vector of optional 2-tuples.  Each element in the
+* vector represents one field in the corresponding LogEvent.  Elements in the vector will correspond
+* 1:1 (and in order) to the fields specified in "fields.match".  The tuples each store the
+* TypeId for this field and the data as Bytes for the field.  There is no need to store the field
+* name because the elements of the vector correspond 1:1 to "fields.match", so there is never any
+* ambiguity about what field is being referred to.  If a field from "fields.match" does not show
+* up in an incoming Event, the CacheEntry will have None in the correspond location in the vector.
+*
+* When ignoring fields, a CacheEntry contains a vector of 3-tuples.  Each element in the vector
+* represents one field in the corresponding LogEvent.  The tuples will each contain the field name,
+* TypeId, and data as Bytes for the corresponding field (in that order).  Since the set of fields
+* that might go into CacheEntries is not known at startup, we must store the field names as part of
+* CacheEntries.  Since Event objects store their field in alphabetic order (as they are backed by a
+* BTreeMap), and we build CacheEntries by iterating over the fields of the incoming Events, we know
+* that the CacheEntries for 2 equivalent events will always contain the fields in the same order.
+**/
+#[derive(PartialEq, Eq, Hash)]
+enum CacheEntry {
+    Match(Vec<Option<(TypeId, Bytes)>>),
+    Ignore(Vec<(Atom, TypeId, Bytes)>),
+}
 
 struct Null;
 
@@ -94,37 +117,54 @@ fn type_id_for_value(val: &Value) -> TypeId {
 }
 
 impl Dedupe {
-    pub fn new(num_entries: usize, match_fields: Vec<Atom>) -> Self {
+    pub fn new(num_entries: usize, field_match_config: FieldMatchConfig) -> Self {
         Self {
             config: DedupeConfig {
-                fields: FieldMatchConfig { match_fields },
+                fields: field_match_config,
                 cache: CacheConfig { num_entries },
             },
             cache: LruCache::new(num_entries),
         }
     }
+}
 
-    // Takes in an Event and returns a CacheEntry to place into the LRU cache containing
-    // all relevant information for the fields that need matching against according to the
-    // specified FieldMatchConfig.
-    pub fn build_cache_entry(&self, event: &Event) -> CacheEntry {
-        let mut entry = CacheEntry::new();
-
-        for field_name in self.config.fields.match_fields.iter() {
-            if let Some(value) = event.as_log().get(field_name) {
-                entry.push(Some((type_id_for_value(&value), value.as_bytes())));
-            } else {
-                entry.push(None);
+// Takes in an Event and returns a CacheEntry to place into the LRU cache containing
+// all relevant information for the fields that need matching against according to the
+// specified FieldMatchConfig.
+fn build_cache_entry(event: &Event, fields: &FieldMatchConfig) -> CacheEntry {
+    match &fields {
+        FieldMatchConfig::MatchFields(fields) => {
+            let mut entry = Vec::new();
+            for field_name in fields.iter() {
+                if let Some(value) = event.as_log().get(field_name) {
+                    entry.push(Some((type_id_for_value(&value), value.as_bytes())));
+                } else {
+                    entry.push(None);
+                }
             }
+            CacheEntry::Match(entry)
         }
+        FieldMatchConfig::IgnoreFields(fields) => {
+            let mut entry = Vec::new();
 
-        entry
+            for (field_name, value) in event.as_log().all_fields() {
+                if !fields.contains(field_name) {
+                    entry.push((
+                        field_name.clone(),
+                        type_id_for_value(&value),
+                        value.as_bytes(),
+                    ));
+                }
+            }
+
+            CacheEntry::Ignore(entry)
+        }
     }
 }
 
 impl Transform for Dedupe {
     fn transform(&mut self, event: Event) -> Option<Event> {
-        let cache_entry = self.build_cache_entry(&event);
+        let cache_entry = build_cache_entry(&event, &self.config.fields);
         if self.cache.put(cache_entry, true).is_some() {
             None
         } else {
@@ -136,12 +176,36 @@ impl Transform for Dedupe {
 #[cfg(test)]
 mod tests {
     use super::Dedupe;
+    use crate::transforms::dedupe::FieldMatchConfig;
     use crate::{event::Event, event::Value, transforms::Transform};
     use std::collections::BTreeMap;
     use string_cache::DefaultAtom as Atom;
 
+    fn make_match_config(fields: Vec<Atom>) -> FieldMatchConfig {
+        FieldMatchConfig::MatchFields(fields)
+    }
+
+    fn make_ignore_config(given_fields: Vec<Atom>) -> FieldMatchConfig {
+        // "message" and "timestamp" are added automatically to all Events
+        let mut fields = vec!["message".into(), "timestamp".into()];
+        fields.extend(given_fields);
+
+        FieldMatchConfig::IgnoreFields(fields)
+    }
+
     #[test]
-    fn dedupe_test_basic_matching() {
+    fn dedupe_match_basic() {
+        let transform = Dedupe::new(5, make_match_config(vec!["matched".into()]));
+        basic(transform);
+    }
+
+    #[test]
+    fn dedupe_ignore_basic() {
+        let transform = Dedupe::new(5, make_ignore_config(vec!["unmatched".into()]));
+        basic(transform);
+    }
+
+    fn basic(mut transform: Dedupe) {
         let mut event1 = Event::from("message");
         event1.as_mut_log().insert("matched", "some value");
         event1.as_mut_log().insert("unmatched", "another value");
@@ -155,8 +219,6 @@ mod tests {
         let mut event3 = Event::from("message");
         event3.as_mut_log().insert("matched", "some value");
         event3.as_mut_log().insert("unmatched", "another value2");
-
-        let mut transform = Dedupe::new(5, vec!["matched".into()]);
 
         // First event should always be passed through as-is.
         let new_event = transform.transform(event1).unwrap();
@@ -172,14 +234,26 @@ mod tests {
     }
 
     #[test]
-    fn dedupe_test_field_name_matters() {
+    fn dedupe_match_field_name_matters() {
+        let transform = Dedupe::new(
+            5,
+            make_match_config(vec!["matched1".into(), "matched2".into()]),
+        );
+        field_name_matters(transform);
+    }
+
+    #[test]
+    fn dedupe_ignore_field_name_matters() {
+        let transform = Dedupe::new(5, make_ignore_config(vec![]));
+        field_name_matters(transform);
+    }
+
+    fn field_name_matters(mut transform: Dedupe) {
         let mut event1 = Event::from("message");
         event1.as_mut_log().insert("matched1", "some value");
 
         let mut event2 = Event::from("message");
         event2.as_mut_log().insert("matched2", "some value");
-
-        let mut transform = Dedupe::new(5, vec!["matched1".into(), "matched2".into()]);
 
         // First event should always be passed through as-is.
         let new_event = transform.transform(event1).unwrap();
@@ -191,10 +265,24 @@ mod tests {
         assert_eq!(new_event.as_log()[&"matched2".into()], "some value".into());
     }
 
+    #[test]
+    fn dedupe_match_field_order_irrelevant() {
+        let transform = Dedupe::new(
+            5,
+            make_match_config(vec!["matched1".into(), "matched2".into()]),
+        );
+        field_order_irrelevant(transform);
+    }
+
+    #[test]
+    fn dedupe_ignore_field_order_irrelevant() {
+        let transform = Dedupe::new(5, make_ignore_config(vec!["randomData".into()]));
+        field_order_irrelevant(transform);
+    }
+
     // Test that two Events that are considered duplicates get handled that way, even
     // if the order of the matched fields is different between the two.
-    #[test]
-    fn dedupe_test_field_order_irrelevant() {
+    fn field_order_irrelevant(mut transform: Dedupe) {
         let mut event1 = Event::from("message");
         event1.as_mut_log().insert("matched1", "value1");
         event1.as_mut_log().insert("matched2", "value2");
@@ -203,8 +291,6 @@ mod tests {
         let mut event2 = Event::from("message");
         event2.as_mut_log().insert("matched2", "value2");
         event2.as_mut_log().insert("matched1", "value1");
-
-        let mut transform = Dedupe::new(5, vec!["matched1".into(), "matched2".into()]);
 
         // First event should always be passed through as-is.
         let new_event = transform.transform(event1).unwrap();
@@ -216,7 +302,20 @@ mod tests {
     }
 
     #[test]
-    fn dedupe_test_age_out() {
+    fn dedupe_match_age_out() {
+        // Construct transform with a cache size of only 1 entry.
+        let transform = Dedupe::new(1, FieldMatchConfig::MatchFields(vec!["matched".into()]));
+        age_out(transform);
+    }
+
+    #[test]
+    fn dedupe_ignore_age_out() {
+        // Construct transform with a cache size of only 1 entry.
+        let transform = Dedupe::new(1, make_ignore_config(vec![]));
+        age_out(transform);
+    }
+
+    fn age_out(mut transform: Dedupe) {
         let mut event1 = Event::from("message");
         event1.as_mut_log().insert("matched", "some value");
 
@@ -225,9 +324,6 @@ mod tests {
 
         // This event is a duplicate of event1, but won't be treated as such.
         let event3 = event1.clone();
-
-        // Construct transform with a cache size of only 1 entry.
-        let mut transform = Dedupe::new(1, vec!["matched".into()]);
 
         // First event should always be passed through as-is.
         let new_event = transform.transform(event1).unwrap();
@@ -244,17 +340,26 @@ mod tests {
         assert_eq!(new_event.as_log()[&"matched".into()], "some value".into());
     }
 
+    #[test]
+    fn dedupe_match_type_matching() {
+        let transform = Dedupe::new(5, make_match_config(vec!["matched".into()]));
+        type_matching(transform);
+    }
+
+    #[test]
+    fn dedupe_ignore_type_matching() {
+        let transform = Dedupe::new(5, make_ignore_config(vec![]));
+        type_matching(transform);
+    }
+
     // Test that two events with values for the matched fields that have different
     // types but the same string representation aren't considered duplicates.
-    #[test]
-    fn dedupe_test_type_matching() {
+    fn type_matching(mut transform: Dedupe) {
         let mut event1 = Event::from("message");
         event1.as_mut_log().insert("matched", "123");
 
         let mut event2 = Event::from("message");
         event2.as_mut_log().insert("matched", 123);
-
-        let mut transform = Dedupe::new(5, vec!["matched".into()]);
 
         // First event should always be passed through as-is.
         let new_event = transform.transform(event1).unwrap();
@@ -266,10 +371,21 @@ mod tests {
         assert_eq!(new_event.as_log()[&"matched".into()], 123.into());
     }
 
-    // Test that two events where the matched field is a sub object and that object contains values
-    // for that have different types but the same string representation aren't considered duplicates.
     #[test]
-    fn dedupe_test_type_matching_nested_objects() {
+    fn dedupe_match_type_matching_nested_objects() {
+        let transform = Dedupe::new(5, make_match_config(vec!["matched".into()]));
+        type_matching_nested_objects(transform);
+    }
+
+    #[test]
+    fn dedupe_ignore_type_matching_nested_objects() {
+        let transform = Dedupe::new(5, make_ignore_config(vec![]));
+        type_matching_nested_objects(transform);
+    }
+
+    // Test that two events where the matched field is a sub object and that object contains values
+    // that have different types but the same string representation aren't considered duplicates.
+    fn type_matching_nested_objects(mut transform: Dedupe) {
         let mut map1: BTreeMap<Atom, Value> = BTreeMap::new();
         map1.insert("key".into(), "123".into());
         let mut event1 = Event::from("message");
@@ -279,8 +395,6 @@ mod tests {
         map2.insert("key".into(), 123.into());
         let mut event2 = Event::from("message");
         event2.as_mut_log().insert("matched", map2);
-
-        let mut transform = Dedupe::new(5, vec!["matched".into()]);
 
         // First event should always be passed through as-is.
         let new_event = transform.transform(event1).unwrap();

--- a/website/docs/reference/transforms/dedupe.md
+++ b/website/docs/reference/transforms/dedupe.md
@@ -39,6 +39,7 @@ import CodeHeader from '@site/src/components/CodeHeader';
 
   # REQUIRED - Fields
   [transforms.my_transform_id.fields]
+    ignore = ["field1", "field2"] # example, no default
     match = ["timestamp"] # default
 ```
 
@@ -125,6 +126,29 @@ Options controlling what fields to match against
 
 <Field
   common={true}
+  defaultValue={null}
+  enumValues={null}
+  examples={[["field1","field2"]]}
+  groups={[]}
+  name={"ignore"}
+  path={"fields"}
+  relevantWhen={null}
+  required={false}
+  templateable={false}
+  type={"[string]"}
+  unit={null}
+  >
+
+#### ignore
+
+The field names to ignore when deciding if an Event is a duplicate.
+
+
+</Field>
+
+
+<Field
+  common={true}
   defaultValue={["timestamp"]}
   enumValues={null}
   examples={[["field1","field2"]]}
@@ -132,7 +156,7 @@ Options controlling what fields to match against
   name={"match"}
   path={"fields"}
   relevantWhen={null}
-  required={true}
+  required={false}
   templateable={false}
   type={"[string]"}
   unit={null}


### PR DESCRIPTION


<!--
**Your PR title must conform to the conventional commit spec!**

  <type>!?(<scope>): <description>

  * `type` = chore, docs, enhancement, newfeat, perf
  * `!` = signals a breaking change
  * `scope` = https://github.com/timberio/vector/blob/master/.github/semantic.yml#L4
  * `description` = short description of the change

Examples:

  * enhancement(file source): Added `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fixed a bug discovering new files
  * perf(observability): Improved logging performance
  * docs: Clarified `batch_size` option
-->